### PR TITLE
Fix warnings (use scalar instead of length)

### DIFF
--- a/lib/Catalyst/Authentication/Credential/JWT.pm
+++ b/lib/Catalyst/Authentication/Credential/JWT.pm
@@ -60,7 +60,7 @@ sub authenticate {
     my $user_data = {
         %{ $authinfo // {} },
     };
-    for (my $i = 0; $i < length(@{ $self->jwt_fields }); $i++) {
+    for (my $i = 0; $i < scalar(@{ $self->jwt_fields }); $i++) {
         $user_data->{$self->store_fields->[$i]} = $jwt_data->{$self->jwt_fields->[$i]};
     }
     my $user_obj = $realm->find_user($user_data, $c);


### PR DESCRIPTION
getting warning on perl v5.30:

```
length() used on @array (did you mean "scalar(@array)"?) at /root/xxx/.plenv/versions/5.30.0/lib/perl5/site_perl/5.30.0/Catalyst/Authentication/Credential/JWT.pm line 63.
```
proposing to use `scalar` instead of `length`